### PR TITLE
feat: static ip fields

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,20 @@ lib_extra_dirs = ~/Documents/Arduino/libraries
 lib_deps = 
   knolleary/PubSubClient @ ^2.8
   4-20ma/ModbusMaster @ ^2.0.1
-  tzapu/WiFiManager @ ^2.0.17
+  https://github.com/tzapu/WiFiManager.git#2.0.5-beta
   bblanchon/ArduinoJson @ ^6.19.2
   aharshac/StringSplitter @ 1.0.0
+monitor_speed = 115200
+monitor_filters = esp8266_exception_decoder
 
+[env:esp01_1m]
+platform = espressif8266@2.6.2 # core 2.7.4
+board = esp01_1m
+framework = arduino
+lib_extra_dirs = ~/Documents/Arduino/libraries
+lib_deps = 
+  knolleary/PubSubClient @ ^2.8
+  4-20ma/ModbusMaster @ ^2.0.1
+  tzapu/WiFiManager @ 2.0.17
+  bblanchon/ArduinoJson @ ^6.19.2
+  aharshac/StringSplitter @ 1.0.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,6 +30,6 @@ lib_extra_dirs = ~/Documents/Arduino/libraries
 lib_deps = 
   knolleary/PubSubClient @ ^2.8
   4-20ma/ModbusMaster @ ^2.0.1
-  tzapu/WiFiManager @ 2.0.17
+  https://github.com/tzapu/WiFiManager.git#2.0.5-beta
   bblanchon/ArduinoJson @ ^6.19.2
   aharshac/StringSplitter @ 1.0.0

--- a/src/WifiAndConfigManager.cpp
+++ b/src/WifiAndConfigManager.cpp
@@ -48,6 +48,7 @@ WifiAndConfigManager::WifiAndConfigManager() {
     mqttPasswordParam = NULL;
     mqttBaseTopicParam = NULL;
     modbusAddressParam = NULL;
+    modbusPollingInSecondsParam = NULL;
 }
 
 void WifiAndConfigManager::saveConfigCallback() {
@@ -104,6 +105,10 @@ void WifiAndConfigManager::setupWifiAndConfig() {
     wm.addParameter(mqttBaseTopicParam);
     wm.addParameter(modbusAddressParam);
     wm.addParameter(modbusPollingInSecondsParam);
+
+   // make static ip fields visible in Wifi menu
+    wm.setShowStaticFields(true);
+    wm.setShowDnsFields(true);
 
     WiFi.mode(WIFI_STA);
     WiFi.hostname(deviceName.c_str());

--- a/src/growatt-sph-spa-esp8266.ino
+++ b/src/growatt-sph-spa-esp8266.ino
@@ -200,7 +200,7 @@ void loop() {
     unsigned long now = millis();
 
     // inverter report
-    if (mqtt->isConnected() && now - lastReportSentAtMillis > wcm.getModbusPollingInSeconds() * 1000) {
+    if (mqtt->isConnected() && now - lastReportSentAtMillis > wcm.getModbusPollingInSeconds() * (unsigned)1000) {
         if (ledStatus == 2) digitalWrite(LED_BUILTIN, LOW);   // Turn the LED on
         GLOG::print(F("LOOP: Polling inverter"));
         inverter->read();


### PR DESCRIPTION
This PR enables the static IP configuration in the wifi menu.

It also rolls back WiFiManager 2.0.17 to 2.0.5-beta because the latest one is causing a bunch of access violations with PROGMEM strings.